### PR TITLE
provide a configuration for the location of java executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Include .class files as test sources
 !*.class
+*-autoloads.el
+*-pkg.el
+*.elc

--- a/jdecomp.el
+++ b/jdecomp.el
@@ -6,7 +6,7 @@
 ;; Keywords: decompile, java, languages, tools
 ;; Package-Requires: ((emacs "24.5"))
 ;; URL: https://github.com/xiongtx/jdecomp
-;; Version: 0.2.0
+;; Version: 0.2.1
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -62,6 +62,11 @@
   :group 'jdecomp
   :options '(cfr fernflower procyon)
   :type '(alist :key-type symbol :value-type (repeat string)))
+
+(defcustom jdecomp-java-program "java"
+  "Path to the Java executable."
+  :group 'jdecomp
+  :type 'string)
 
 
 ;;;; Utilities
@@ -201,7 +206,7 @@ applicable."
   (jdecomp--ensure-decompiler 'cfr)
   (with-output-to-string
     (let ((classpath (or jar (file-name-directory file) default-directory)))
-      (apply #'call-process "java" nil standard-output nil
+      (apply #'call-process jdecomp-java-program nil standard-output nil
              `("-jar" ,(expand-file-name (jdecomp--decompiler-path 'cfr))
                "--extraclasspath" ,classpath
                ,@(jdecomp--decompiler-options 'cfr)
@@ -222,7 +227,7 @@ was extracted from a JAR with `jdecomp--extract-to-file'."
                           (jdecomp--make-temp-file (concat "jdecomp" (file-name-sans-extension file)) t))))
       ;; The java-decompiler.jar is not executable
       ;; See: http://stackoverflow.com/a/39868281/864684
-      (apply #'call-process "java" nil nil nil
+      (apply #'call-process jdecomp-java-program nil nil nil
              `("-cp" ,(expand-file-name (jdecomp--decompiler-path 'fernflower))
                "org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler"
                "-cp" ,classpath
@@ -262,7 +267,7 @@ Optional parameter EXTRACTED-P, when non-nil, indicates that FILE
 was extracted from a JAR with `jdecomp--extract-to-file'."
   (jdecomp--ensure-decompiler 'procyon)
   (with-output-to-string
-    (apply #'call-process "java" nil standard-output nil
+    (apply #'call-process jdecomp-java-program nil standard-output nil
            `("-jar" ,(expand-file-name (jdecomp--decompiler-path 'procyon))
              ,@(jdecomp--decompiler-options 'procyon)
              ,file))))

--- a/jdecomp.el
+++ b/jdecomp.el
@@ -47,9 +47,9 @@
   "Type of Java decompiler to use."
   :group 'jdecomp
   :type '(radio
-          (const :tag "CFR" 'cfr)
-          (const :tag "Fernflower" 'fernflower)
-          (const :tag "Procyon" 'procyon)))
+          (const :tag "CFR" cfr)
+          (const :tag "Fernflower" fernflower)
+          (const :tag "Procyon" procyon)))
 
 (defcustom jdecomp-decompiler-paths nil
   "Alist of Java decompiler types and their paths."
@@ -178,10 +178,10 @@ Optional parameter DECOMPILER-TYPE defaults to
 `jdecomp-decompiler-type'."
   (condition-case nil
       (cl-ecase decompiler-type
-        ('cfr #'jdecomp--cfr-command)
-        ('fernflower #'jdecomp--fernflower-command)
-        ('procyon #'jdecomp--procyon-command))
-    (error (user-error "%s is not a known decompiler" decompiler-type))))
+        (cfr #'jdecomp--cfr-command)
+        (fernflower #'jdecomp--fernflower-command)
+        (procyon #'jdecomp--procyon-command))
+    (user-error "%s is not a known decompiler" decompiler-type)))
 
 (cl-defun jdecomp--ensure-decompiler (&optional (decompiler-type jdecomp-decompiler-type))
   "Ensure that the decompiler for DECOMPILER-TYPE is available.
@@ -190,10 +190,10 @@ Optional parameter DECOMPILER-TYPE defaults to
 `jdecomp-decompiler-type'."
   (unless (condition-case nil
               (cl-ecase decompiler-type
-                ('cfr (jdecomp--jar-p (jdecomp--decompiler-path 'cfr)))
-                ('fernflower (jdecomp--jar-p (jdecomp--decompiler-path 'fernflower)))
-                ('procyon (jdecomp--jar-p (jdecomp--decompiler-path 'procyon))))
-            (error (user-error "%s is not a known decompiler" decompiler-type)))
+                (cfr (jdecomp--jar-p (jdecomp--decompiler-path 'cfr)))
+                (fernflower (jdecomp--jar-p (jdecomp--decompiler-path 'fernflower)))
+                (procyon (jdecomp--jar-p (jdecomp--decompiler-path 'procyon))))
+            (user-error "%s is not a known decompiler" decompiler-type))
     (user-error "%s decompiler is not available" decompiler-type)))
 
 (defun jdecomp--cfr-command (file &optional jar)
@@ -342,7 +342,7 @@ Optional parameter JAR is the name of the JAR archive FILE is
 in."
   ;; Check that FILE is a class file
   (unless (jdecomp--classfile-p file)
-    (user-error (format "%s is not a Java class file" file)))
+    (user-error "%s is not a Java class file" file))
 
   (let ((result (funcall (jdecomp--decompile-command) file jar))
         (buf (get-buffer-create (jdecomp--decompiled-buffer-name file))))


### PR DESCRIPTION
Recent Fernflower requires JDK17 to run, however, I have to use JDK11 as my main JDK on the system, and I can't switch to JDK17 and back whenever I need decompilation. This patch introduces a custom variable to specify what Java executable to use. Nothing will change for existing users by default. This is the same approach taken by packages such as lsp-java or eglot.

Additionally, I fixed a bug - when modern Fernflower runs on older JDK it doesn't produce any files, hence `(cl-first (jdecomp--java-files destination))` returned `nil`, and (insert-file-contents nil)` caused an ambigous error.  Now, we check if there are files first, and if not throw a proper error, with the process output for easier debugging.

Also fixed a bunch of warnings.